### PR TITLE
Release 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     # Master
     # @link https://github.com/WordPress/WordPress
     - WP_VERSION=master WP_MULTISITE=1
-    
+
 # Disable XDebug
 before_install:
     - phpenv config-rm xdebug.ini

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ URI Modern Home 1.0.1 adds stylesheets for features.
 ## Theme details
 
 [![Master Build Status](https://travis-ci.org/uriweb/uri-modern-home.svg?branch=master "Master build status")](https://travis-ci.org/uriweb/uri-modern-home)
-[![Develop Build Status](https://travis-ci.org/uriweb/uri-modern-home.svg?branch=develop "Develop build status")](https://travis-ci.org/uriweb/uri-modern-home)
 [![CodeFactor](https://www.codefactor.io/repository/github/uriweb/uri-modern-home/badge/master)](https://www.codefactor.io/repository/github/uriweb/uri-modern-home/overview/master)
 [![devDependencies Status](https://david-dm.org/uriweb/uri-modern-home/dev-status.svg "devDependencies status")](https://david-dm.org/uriweb/uri-modern-home?type=dev)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ URI Modern Home 1.0.1 adds stylesheets for features.
 
 [![Master Build Status](https://travis-ci.org/uriweb/uri-modern-home.svg?branch=master "Master build status")](https://travis-ci.org/uriweb/uri-modern-home)
 [![CodeFactor](https://www.codefactor.io/repository/github/uriweb/uri-modern-home/badge/master)](https://www.codefactor.io/repository/github/uriweb/uri-modern-home/overview/master)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/e0a03abdc4344cf79f92384a7ca76f27?branch=master)](https://www.codacy.com/app/uriweb/uri-modern-home?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=uriweb/uri-modern-home&amp;utm_campaign=Badge_Grade)
 [![devDependencies Status](https://david-dm.org/uriweb/uri-modern-home/dev-status.svg "devDependencies status")](https://david-dm.org/uriweb/uri-modern-home?type=dev)
 
 Contributors: Brandon Fuller  

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Contributors: Brandon Fuller
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 4.9  
-Stable tag: 1.0.1  
+Stable tag: 1.0.2  

--- a/features/2018/philosophy-of-comedy.css
+++ b/features/2018/philosophy-of-comedy.css
@@ -85,11 +85,6 @@ h2 {
 	max-width: 360px;
 }
 
-.caption p {
-	line-height: 125%;
-	margin-bottom: 1rem;
-}
-
 .caption:after {
 	display: block;
 	content: '';
@@ -97,6 +92,20 @@ h2 {
 	height: 1px;
 	background: #ff6872;
 	margin-top: 1rem;
+}
+
+.caption p {
+	line-height: 125%;
+	margin-bottom: 1rem;
+}
+
+.caption a {
+	text-decoration: none;
+}
+
+.caption a:hover,
+.caption a:focus {
+	text-decoration: underline;
 }
 
 .credit {

--- a/features/2018/philosophy-of-comedy.css
+++ b/features/2018/philosophy-of-comedy.css
@@ -72,12 +72,6 @@ h2 {
 	width: 100vw;
 }
 
-.artbaord:after {
-	display: block;
-	content: '';
-	clear: both;
-}
-
 .artboard img {
 	width: 100%;
 	height: auto;

--- a/features/2018/philosophy-of-comedy.css
+++ b/features/2018/philosophy-of-comedy.css
@@ -137,6 +137,7 @@ h2 {
 
 #hero img {
 	width: 200%;
+	max-width: initial;
 	height: auto;
 	margin-left: -50%;
 	padding: 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,22 +42,6 @@ var sassOptions = {
   outputStyle: 'compressed' //expanded, nested, compact, compressed
 };
 
-// Generate build number
-function getBuild() {
-    
-    var d, start, day, seconds, build;
-    
-    d = new Date();
-    start = new Date(d.getUTCFullYear(), 0, 0);
-    day = Math.floor( (d - start) / 86400000);
-    seconds = (d.getUTCHours() * 3600) + (d.getUTCMinutes() * 60) + d.getUTCSeconds();
-    
-    build = d.getUTCFullYear().toString().slice(2) + ("00" + (day)).slice(-3) + '.' + seconds;
-
-    return build;
-    
-}
-
 // JS concat, strip debugging and minify
 gulp.task('scripts', scripts);
 
@@ -122,9 +106,7 @@ function sniffs(done) {
     
     return gulp.src('.', {read:false})
         .pipe(shell(['./.sniff']));
-    
-    done();
-    //console.log('sniffs ran');
+
 }
 
 // watch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-modern-home",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "URI Modern Home is a WordPress theme designed for the University of Rhode Island homepage site. It is a child theme of URI Modern.",
   "themeName": "URI Modern Home",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@ Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern Home is a WordPress theme designed for the University of Rhode Island homepage site. It is a child theme of URI Modern.
 Template: uri-modern
-Version: 1.0.1
+Version: 1.0.2
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.0.1
+@version v1.0.2
 @author Brandon Fuller <bjcfuller@uri.edu>
 
 */

--- a/template-parts/uri-featured-posts-hero.php
+++ b/template-parts/uri-featured-posts-hero.php
@@ -5,7 +5,7 @@
  * @package uri-modern-home
  */
 
-	$html .= '<div>';
+	$html .= '<div class="uri-featured-posts-hero-wrapper">';
 
 	foreach ( $posts_array as $post ) {
 	setup_postdata( $post );
@@ -13,7 +13,7 @@
 	$excerpt = get_field( 'hero_excerpt', $post->ID, false );
 
 	if ( ! empty( $excerpt ) ) {
-		$html .= $excerpt;
+		$html .= do_shortcode( $excerpt );
 		} else {
 		$html .= 'Hero excerpt is empty.  :(';
 		}


### PR DESCRIPTION
## What's new in 1.0.2

URI Modern Home 1.0.2 is a bug fix release.

* Fixes an error that caused the Philosophy of Comedy hero image to not display properly on mobile
* The hero excerpt field now supports shortcodes

