### PR TITLE
Hotfix 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 URI Modern Home is a WordPress theme designed for the University of Rhode Island homepage site. It is a child theme of URI Modern.
 
-## What's new in 1.9
+## What's new in 1.9.1
+
+URI Modern Home 1.9.1 is a bug fix release.
+
+* Fixes an issue that may prevent cache busting for the parent theme stylesheet
+
+## New in 1.9
 
 URI Modern Home 1.9 is a minor release.
 
@@ -32,4 +38,4 @@ Contributors: Brandon Fuller, John Pennypacker
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 5.2  
-Stable tag: 1.9.0  
+Stable tag: 1.9.1  

--- a/functions.php
+++ b/functions.php
@@ -13,8 +13,9 @@
 function uri_modern_home_enqueues() {
 
 	$parent_style = 'uri-modern-style';
+	$parent_dir_name = wp_get_theme()->get( 'Template' );
 
-	wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css', array(), wp_get_theme( $parent_dir_name )->get( 'Version' ) );
 
 	wp_enqueue_style( 'uri-modern-home-style', get_stylesheet_directory_uri() . '/style.css', array( $parent_style ), wp_get_theme()->get( 'Version' ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-modern-home",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "URI Modern Home is a WordPress theme designed for the University of Rhode Island homepage site. It is a child theme of URI Modern.",
   "themeName": "URI Modern Home",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@ Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern Home is a WordPress theme designed for the University of Rhode Island homepage site. It is a child theme of URI Modern.
 Template: uri-modern
-Version: 1.9.0
+Version: 1.9.1
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.9.0
+@version v1.9.1
 @author Brandon Fuller <bjcfuller@uri.edu>
 @author John Pennypacker <jpennypacker@uri.edu>
 


### PR DESCRIPTION
## What's new in 1.9.1

URI Modern Home 1.9.1 is a bug fix release.

* Fixes an issue that may prevent cache busting for the parent theme stylesheet